### PR TITLE
Add Supabase-based guard scheduling UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# reset
+# Gestion des gardes (Supabase + GitHub Pages)
+
+Ce projet fournit une interface statique (compatible GitHub Pages) pour gérer les comptes et les saisies de gardes en s'appuyant sur Supabase.
+
+## Fonctionnalités
+
+- **Connexion Supabase** : à l'ouverture de chaque page, une fenêtre invite à renseigner l'URL et la clé API Supabase (stockées dans le navigateur).
+- **Gestion des utilisateurs** : l'espace administrateur permet de créer, modifier, supprimer des comptes et de changer les mots de passe.
+- **Saisie des gardes** : l'espace médecin permet de saisir ses gardes et de les consulter en temps réel.
+- **Disponibilités remplaçants** : l'espace remplaçant permet de déclarer ses créneaux disponibles.
+- **Mise à jour temps réel** : les listes se mettent à jour automatiquement via les canaux Supabase Realtime.
+
+## Installation et déploiement
+
+1. Déployez ce dossier sur GitHub Pages ou tout autre hébergeur de fichiers statiques.
+2. Créez un projet Supabase et exécutez le script [`supabase_schema.sql`](./supabase_schema.sql) dans la console SQL pour créer les tables, l'administrateur initial (`admin` / `Melatonine`) et les politiques de sécurité.
+3. Récupérez l'URL Supabase (`https://votre-instance.supabase.co`) et une clé API (clé de service recommandée pour l'administration).
+4. Ouvrez `index.html`, saisissez l'URL et la clé API lorsque la fenêtre s'affiche, puis connectez-vous avec le compte `admin` / `Melatonine`.
+5. Depuis l'espace administrateur, créez les comptes pour les médecins et remplaçants.
+
+> ℹ️ **Sécurité** : le script SQL fournit des politiques permissives pour simplifier les tests. Adaptez-les pour vos besoins (politiques spécifiques par rôle, restrictions sur les colonnes, etc.). Pour un usage public, préférez utiliser une clé de service côté serveur.
+
+## Structure des pages
+
+- `index.html` : écran de connexion pour tous les utilisateurs.
+- `admin.html` : interface d'administration des comptes.
+- `medecin.html` : saisie et suivi des gardes pour les médecins.
+- `remplacant.html` : saisie des disponibilités pour les remplaçants.
+
+Chaque page importe `js/supabaseClient.js` pour gérer la connexion Supabase et la session utilisateur (stockée dans le `localStorage`).
+
+## Développement
+
+Aucune dépendance additionnelle n'est nécessaire : l'application charge `@supabase/supabase-js` via un CDN. Pour tester en local, servez simplement les fichiers statiques (ex. `npx serve .`).

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Administration - Gestion des gardes</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div id="connection-modal" class="modal-backdrop hidden" role="dialog" aria-modal="true">
+      <section class="modal">
+        <h1>Connexion à Supabase</h1>
+        <p>Pour gérer les comptes, configurez l'accès à votre instance Supabase.</p>
+        <form id="connection-form" class="card">
+          <label for="supabaseUrl">URL Supabase</label>
+          <input id="supabaseUrl" name="supabaseUrl" type="url" required />
+
+          <label for="supabaseKey">Clé API</label>
+          <input id="supabaseKey" name="supabaseKey" type="password" required />
+
+          <div class="stack" style="justify-content: flex-end;">
+            <button type="submit">Se connecter</button>
+          </div>
+        </form>
+      </section>
+    </div>
+    <main>
+      <section class="card">
+        <header>
+          <div>
+            <h1>Espace administrateur</h1>
+            <p>Créez, modifiez et supprimez les comptes utilisateurs.</p>
+          </div>
+          <nav>
+            <button id="disconnect" class="secondary" type="button">Changer d'instance</button>
+            <button id="logout" class="secondary" type="button">Se déconnecter</button>
+          </nav>
+        </header>
+        <section>
+          <h2>Créer un compte</h2>
+          <form id="create-user-form">
+            <label for="new-username">Identifiant</label>
+            <input id="new-username" name="username" type="text" required />
+
+            <label for="new-password">Mot de passe</label>
+            <input id="new-password" name="password" type="password" required />
+
+            <label for="new-role">Rôle</label>
+            <select id="new-role" name="role" required>
+              <option value="administrateur">Administrateur</option>
+              <option value="medecin">Médecin</option>
+              <option value="remplacant">Remplaçant</option>
+            </select>
+
+            <button type="submit">Créer l'utilisateur</button>
+            <p id="create-feedback" role="status"></p>
+          </form>
+        </section>
+        <section>
+          <h2>Comptes existants</h2>
+          <div class="card">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Identifiant</th>
+                  <th>Rôle</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="users-body"></tbody>
+            </table>
+            <p id="users-feedback" role="status"></p>
+          </div>
+        </section>
+      </section>
+    </main>
+    <script type="module">
+      import {
+        initializeConnectionModal,
+        requireRole,
+        getCurrentUser,
+        setCurrentUser,
+        getSupabaseClient,
+        onSupabaseReady
+      } from './js/supabaseClient.js';
+
+      const currentUser = getCurrentUser();
+      if (!currentUser) {
+        window.location.replace('index.html');
+      }
+      requireRole('administrateur');
+
+      initializeConnectionModal();
+
+      const logoutBtn = document.querySelector('#logout');
+      logoutBtn.addEventListener('click', () => {
+        setCurrentUser(null);
+        window.location.replace('index.html');
+      });
+
+      const createForm = document.querySelector('#create-user-form');
+      const createFeedback = document.querySelector('#create-feedback');
+      const usersBody = document.querySelector('#users-body');
+      const usersFeedback = document.querySelector('#users-feedback');
+      let channel;
+
+      const roles = {
+        administrateur: 'Administrateur',
+        medecin: 'Médecin',
+        remplacant: 'Remplaçant'
+      };
+
+      const renderUsers = (users) => {
+        usersBody.innerHTML = '';
+        users.forEach((user) => {
+          const row = document.createElement('tr');
+          row.innerHTML = `
+            <td>${user.username}</td>
+            <td>
+              <select data-action="change-role" data-id="${user.id}">
+                ${Object.entries(roles)
+                  .map(
+                    ([value, label]) => `
+                      <option value="${value}" ${user.role === value ? 'selected' : ''}>${label}</option>
+                    `
+                  )
+                  .join('')}
+              </select>
+            </td>
+            <td>
+              <div class="table-actions">
+                <button data-action="reset-password" data-id="${user.id}">Définir le mot de passe</button>
+                <button data-action="delete" data-id="${user.id}" class="danger">Supprimer</button>
+              </div>
+            </td>
+          `;
+          usersBody.appendChild(row);
+        });
+      };
+
+      const loadUsers = async () => {
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        const { data, error } = await supabase.from('users').select('id, username, role').order('username');
+        if (error) {
+          console.error(error);
+          usersFeedback.textContent = "Impossible de récupérer les utilisateurs.";
+          return;
+        }
+        usersFeedback.textContent = `${data.length} utilisateur(s).`;
+        renderUsers(data);
+      };
+
+      createForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        const formData = new FormData(createForm);
+        const payload = {
+          username: formData.get('username').trim(),
+          password: formData.get('password').trim(),
+          role: formData.get('role')
+        };
+
+        if (!payload.username || !payload.password) {
+          createFeedback.textContent = 'Identifiant et mot de passe sont obligatoires.';
+          return;
+        }
+
+        const { error } = await supabase.from('users').insert(payload);
+        if (error) {
+          console.error(error);
+          createFeedback.textContent = "Impossible de créer l'utilisateur.";
+          return;
+        }
+
+        createFeedback.textContent = "Utilisateur créé.";
+        createForm.reset();
+      });
+
+      usersBody.addEventListener('change', async (event) => {
+        const target = event.target;
+        if (target.dataset.action === 'change-role') {
+          await onSupabaseReady();
+          const supabase = getSupabaseClient();
+          const id = target.dataset.id;
+          const role = target.value;
+          const { error } = await supabase.from('users').update({ role }).eq('id', id);
+          if (error) {
+            console.error(error);
+            alert('Impossible de mettre à jour le rôle.');
+          }
+        }
+      });
+
+      usersBody.addEventListener('click', async (event) => {
+        const button = event.target.closest('button');
+        if (!button) {
+          return;
+        }
+        const { action, id } = button.dataset;
+        if (!action || !id) {
+          return;
+        }
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+
+        if (action === 'delete') {
+          if (!confirm('Supprimer cet utilisateur ?')) {
+            return;
+          }
+          const { error } = await supabase.from('users').delete().eq('id', id);
+          if (error) {
+            console.error(error);
+            alert('Impossible de supprimer cet utilisateur.');
+          }
+        }
+
+        if (action === 'reset-password') {
+          const newPassword = prompt('Nouveau mot de passe :');
+          if (!newPassword) {
+            return;
+          }
+          const { error } = await supabase.from('users').update({ password: newPassword }).eq('id', id);
+          if (error) {
+            console.error(error);
+            alert('Impossible de mettre à jour le mot de passe.');
+          }
+        }
+      });
+
+      const subscribeToChanges = async () => {
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        channel = supabase
+          .channel('users-changes')
+          .on('postgres_changes', { event: '*', schema: 'public', table: 'users' }, () => {
+            loadUsers();
+          })
+          .subscribe();
+      };
+
+      loadUsers();
+      subscribeToChanges();
+
+      window.addEventListener('beforeunload', () => {
+        channel?.unsubscribe();
+      });
+    </script>
+  </body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,188 @@
+:root {
+  color-scheme: light dark;
+  --primary: #2c3e50;
+  --accent: #3498db;
+  --danger: #e74c3c;
+  --success: #27ae60;
+  --bg: #f5f7fa;
+  --text: #2c3e50;
+  --radius: 12px;
+  --shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+  --transition: 0.2s ease-in-out;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+main {
+  width: min(960px, 95vw);
+  margin: 48px auto;
+  display: grid;
+  gap: 32px;
+}
+
+.card {
+  background: #ffffffcc;
+  backdrop-filter: blur(16px);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 32px;
+}
+
+h1, h2, h3 {
+  margin-top: 0;
+  color: var(--primary);
+}
+
+form {
+  display: grid;
+  gap: 16px;
+}
+
+label {
+  font-weight: 600;
+}
+
+input, select, textarea, button {
+  font: inherit;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid #dfe6e9;
+  transition: border var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(52, 152, 219, 0.2);
+}
+
+button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(52, 152, 219, 0.25);
+}
+
+button.danger {
+  background: var(--danger);
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid var(--primary);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead {
+  background: rgba(52, 152, 219, 0.1);
+}
+
+.table th, .table td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid #ecf0f1;
+}
+
+.badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(52, 152, 219, 0.15);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.stack {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+header nav {
+  display: flex;
+  gap: 12px;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  place-items: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  padding: 32px;
+  border-radius: var(--radius);
+  width: min(480px, 90vw);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 16px;
+}
+
+.hidden {
+  display: none !important;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.table-actions {
+  display: flex;
+  gap: 8px;
+}
+
+@media (max-width: 768px) {
+  body {
+    align-items: flex-start;
+  }
+
+  main {
+    margin: 24px auto;
+  }
+
+  header {
+    flex-direction: column;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gestion des gardes - Connexion</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div id="connection-modal" class="modal-backdrop hidden" role="dialog" aria-modal="true">
+      <section class="modal">
+        <h1>Connexion à Supabase</h1>
+        <p>Renseignez l'URL de votre instance Supabase et la clé API (service role ou anon) habilitée à manipuler les tables.</p>
+        <form id="connection-form" class="card">
+          <label for="supabaseUrl">URL Supabase</label>
+          <input id="supabaseUrl" name="supabaseUrl" type="url" placeholder="https://xyzcompany.supabase.co" required />
+
+          <label for="supabaseKey">Clé API</label>
+          <input id="supabaseKey" name="supabaseKey" type="password" placeholder="Votre clé API" required />
+
+          <div class="stack" style="justify-content: flex-end;">
+            <button type="submit">Se connecter</button>
+          </div>
+        </form>
+      </section>
+    </div>
+    <main>
+      <section class="card">
+        <header>
+          <h1>Gestion des gardes</h1>
+          <nav>
+            <a href="https://supabase.com/docs" target="_blank" rel="noreferrer">Documentation Supabase</a>
+          </nav>
+        </header>
+        <p>Merci de vous authentifier pour accéder à votre espace.</p>
+        <form id="login-form">
+          <label for="username">Identifiant</label>
+          <input id="username" name="username" type="text" autocomplete="username" placeholder="Votre identifiant" required />
+
+          <label for="password">Mot de passe</label>
+          <input id="password" name="password" type="password" autocomplete="current-password" placeholder="Votre mot de passe" required />
+
+          <button type="submit">Se connecter</button>
+          <p id="login-feedback" role="status"></p>
+        </form>
+      </section>
+    </main>
+    <script type="module">
+      import {
+        initializeConnectionModal,
+        getSupabaseClient,
+        onSupabaseReady,
+        setCurrentUser,
+        getCurrentUser
+      } from './js/supabaseClient.js';
+
+      initializeConnectionModal();
+
+      const feedback = document.querySelector('#login-feedback');
+      const form = document.querySelector('#login-form');
+
+      const redirectAfterLogin = (user) => {
+        const destinations = {
+          administrateur: 'admin.html',
+          medecin: 'medecin.html',
+          remplacant: 'remplacant.html'
+        };
+        const target = destinations[user.role];
+        if (target) {
+          window.location.assign(target);
+        } else {
+          feedback.textContent = `Rôle inconnu: ${user.role}`;
+        }
+      };
+
+      const existingUser = getCurrentUser();
+      if (existingUser) {
+        redirectAfterLogin(existingUser);
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        feedback.textContent = '';
+        form.querySelector('button[type="submit"]').disabled = true;
+
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        if (!supabase) {
+          feedback.textContent = 'Veuillez configurer la connexion à Supabase.';
+          form.querySelector('button[type="submit"]').disabled = false;
+          return;
+        }
+
+        const formData = new FormData(form);
+        const username = formData.get('username').trim();
+        const password = formData.get('password').trim();
+
+        const { data, error } = await supabase
+          .from('users')
+          .select('id, username, role')
+          .eq('username', username)
+          .eq('password', password)
+          .maybeSingle();
+
+        form.querySelector('button[type="submit"]').disabled = false;
+
+        if (error) {
+          console.error(error);
+          feedback.textContent = 'Impossible de vérifier vos identifiants. Vérifiez la configuration Supabase.';
+          return;
+        }
+
+        if (!data) {
+          feedback.textContent = 'Identifiant ou mot de passe invalide.';
+          return;
+        }
+
+        setCurrentUser(data);
+        redirectAfterLogin(data);
+      });
+    </script>
+  </body>
+</html>

--- a/js/supabaseClient.js
+++ b/js/supabaseClient.js
@@ -1,0 +1,132 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+const STORAGE_KEYS = {
+  url: 'guardes:supabaseUrl',
+  key: 'guardes:supabaseKey',
+  user: 'guardes:currentUser'
+};
+
+let client = null;
+let resolveReady;
+const readyPromise = new Promise((resolve) => {
+  resolveReady = resolve;
+});
+
+function buildClient(url, key) {
+  if (!url || !key) {
+    return null;
+  }
+  client = createClient(url, key);
+  resolveReady?.(client);
+  return client;
+}
+
+export function getStoredConnection() {
+  return {
+    url: localStorage.getItem(STORAGE_KEYS.url) ?? '',
+    key: localStorage.getItem(STORAGE_KEYS.key) ?? ''
+  };
+}
+
+export function setStoredConnection(url, key) {
+  localStorage.setItem(STORAGE_KEYS.url, url);
+  localStorage.setItem(STORAGE_KEYS.key, key);
+  return buildClient(url, key);
+}
+
+export function clearStoredConnection() {
+  localStorage.removeItem(STORAGE_KEYS.url);
+  localStorage.removeItem(STORAGE_KEYS.key);
+  client = null;
+}
+
+export function getSupabaseClient() {
+  if (client) {
+    return client;
+  }
+  const { url, key } = getStoredConnection();
+  if (!url || !key) {
+    return null;
+  }
+  return buildClient(url, key);
+}
+
+export function onSupabaseReady() {
+  return readyPromise;
+}
+
+export function getCurrentUser() {
+  const raw = localStorage.getItem(STORAGE_KEYS.user);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error('Failed to parse stored user', error);
+    return null;
+  }
+}
+
+export function setCurrentUser(user) {
+  if (user) {
+    localStorage.setItem(STORAGE_KEYS.user, JSON.stringify(user));
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.user);
+  }
+}
+
+export function requireRole(role) {
+  const user = getCurrentUser();
+  if (!user || user.role !== role) {
+    window.location.assign('index.html');
+  }
+}
+
+export function initializeConnectionModal() {
+  const modal = document.querySelector('#connection-modal');
+  const form = document.querySelector('#connection-form');
+  const disconnectBtn = document.querySelector('#disconnect');
+
+  if (!modal || !form) {
+    throw new Error('Connection modal markup missing from page.');
+  }
+
+  const { url, key } = getStoredConnection();
+  if (url) {
+    form.elements['supabaseUrl'].value = url;
+  }
+  if (key) {
+    form.elements['supabaseKey'].value = key;
+  }
+
+  const connect = (event) => {
+    event?.preventDefault();
+    const supabaseUrl = form.elements['supabaseUrl'].value.trim();
+    const supabaseKey = form.elements['supabaseKey'].value.trim();
+
+    if (!supabaseUrl || !supabaseKey) {
+      alert('Merci de renseigner l\'URL et la clé API Supabase.');
+      return;
+    }
+
+    setStoredConnection(supabaseUrl, supabaseKey);
+    modal.classList.add('hidden');
+  };
+
+  form.addEventListener('submit', connect);
+
+  if (disconnectBtn) {
+    disconnectBtn.addEventListener('click', () => {
+      clearStoredConnection();
+      modal.classList.remove('hidden');
+    });
+  }
+
+  if (url && key) {
+    buildClient(url, key);
+    modal.classList.add('hidden');
+  } else {
+    modal.classList.remove('hidden');
+  }
+}

--- a/medecin.html
+++ b/medecin.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Espace Médecin - Gestion des gardes</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div id="connection-modal" class="modal-backdrop hidden" role="dialog" aria-modal="true">
+      <section class="modal">
+        <h1>Connexion à Supabase</h1>
+        <p>Indiquez vos paramètres Supabase pour enregistrer vos gardes.</p>
+        <form id="connection-form" class="card">
+          <label for="supabaseUrl">URL Supabase</label>
+          <input id="supabaseUrl" name="supabaseUrl" type="url" required />
+
+          <label for="supabaseKey">Clé API</label>
+          <input id="supabaseKey" name="supabaseKey" type="password" required />
+
+          <div class="stack" style="justify-content: flex-end;">
+            <button type="submit">Se connecter</button>
+          </div>
+        </form>
+      </section>
+    </div>
+    <main>
+      <section class="card">
+        <header>
+          <div>
+            <h1>Espace Médecin</h1>
+            <p>Déclarez vos gardes et disponibilités.</p>
+          </div>
+          <nav>
+            <button id="disconnect" class="secondary" type="button">Changer d'instance</button>
+            <button id="logout" class="secondary" type="button">Se déconnecter</button>
+          </nav>
+        </header>
+        <section>
+          <h2>Nouvelle garde</h2>
+          <form id="guard-form">
+            <label for="guard-date">Date</label>
+            <input id="guard-date" name="date" type="date" required />
+
+            <label for="guard-type">Type de garde</label>
+            <select id="guard-type" name="type" required>
+              <option value="Jour">Jour</option>
+              <option value="Nuit">Nuit</option>
+              <option value="Week-end">Week-end</option>
+            </select>
+
+            <label for="guard-notes">Notes</label>
+            <textarea id="guard-notes" name="notes" rows="3" placeholder="Informations complémentaires"></textarea>
+
+            <button type="submit">Enregistrer la garde</button>
+            <p id="guard-feedback" role="status"></p>
+          </form>
+        </section>
+        <section>
+          <h2>Mes gardes</h2>
+          <div class="card">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Type</th>
+                  <th>Notes</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="guards-body"></tbody>
+            </table>
+            <p id="guards-feedback" role="status"></p>
+          </div>
+        </section>
+      </section>
+    </main>
+    <script type="module">
+      import {
+        initializeConnectionModal,
+        requireRole,
+        getCurrentUser,
+        setCurrentUser,
+        getSupabaseClient,
+        onSupabaseReady
+      } from './js/supabaseClient.js';
+
+      const user = getCurrentUser();
+      if (!user) {
+        window.location.replace('index.html');
+      }
+      requireRole('medecin');
+
+      initializeConnectionModal();
+
+      document.querySelector('#logout').addEventListener('click', () => {
+        setCurrentUser(null);
+        window.location.replace('index.html');
+      });
+
+      const form = document.querySelector('#guard-form');
+      const feedback = document.querySelector('#guard-feedback');
+      const tableBody = document.querySelector('#guards-body');
+      const listFeedback = document.querySelector('#guards-feedback');
+      let channel;
+
+      const formatDate = (value) => new Intl.DateTimeFormat('fr-FR').format(new Date(value));
+
+      const renderGuards = (guards) => {
+        tableBody.innerHTML = '';
+        guards.forEach((guard) => {
+          const row = document.createElement('tr');
+          row.innerHTML = `
+            <td>${formatDate(guard.date)}</td>
+            <td><span class="badge">${guard.type}</span></td>
+            <td>${guard.notes ?? ''}</td>
+            <td>
+              <div class="table-actions">
+                <button data-action="delete" data-id="${guard.id}" class="danger">Supprimer</button>
+              </div>
+            </td>
+          `;
+          tableBody.appendChild(row);
+        });
+      };
+
+      const loadGuards = async () => {
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        const { data, error } = await supabase
+          .from('doctor_entries')
+          .select('id, date, type, notes')
+          .eq('user_id', user.id)
+          .order('date', { ascending: true });
+        if (error) {
+          console.error(error);
+          listFeedback.textContent = 'Impossible de récupérer vos gardes.';
+          return;
+        }
+        listFeedback.textContent = `${data.length} garde(s).`;
+        renderGuards(data);
+      };
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        const formData = new FormData(form);
+        const payload = {
+          user_id: user.id,
+          date: formData.get('date'),
+          type: formData.get('type'),
+          notes: formData.get('notes')?.trim() || null
+        };
+
+        const { error } = await supabase.from('doctor_entries').insert(payload);
+        if (error) {
+          console.error(error);
+          feedback.textContent = "Impossible d'enregistrer la garde.";
+          return;
+        }
+
+        feedback.textContent = 'Garde enregistrée !';
+        form.reset();
+      });
+
+      tableBody.addEventListener('click', async (event) => {
+        const button = event.target.closest('button');
+        if (!button) {
+          return;
+        }
+        if (button.dataset.action === 'delete') {
+          if (!confirm('Supprimer cette garde ?')) {
+            return;
+          }
+          await onSupabaseReady();
+          const supabase = getSupabaseClient();
+          const { error } = await supabase.from('doctor_entries').delete().eq('id', button.dataset.id);
+          if (error) {
+            console.error(error);
+            alert('Impossible de supprimer la garde.');
+          }
+        }
+      });
+
+      const subscribe = async () => {
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        channel = supabase
+          .channel('doctor-entries')
+          .on('postgres_changes', { event: '*', schema: 'public', table: 'doctor_entries', filter: `user_id=eq.${user.id}` }, () => {
+            loadGuards();
+          })
+          .subscribe();
+      };
+
+      loadGuards();
+      subscribe();
+
+      window.addEventListener('beforeunload', () => {
+        channel?.unsubscribe();
+      });
+    </script>
+  </body>
+</html>

--- a/remplacant.html
+++ b/remplacant.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Espace Remplaçant - Gestion des gardes</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div id="connection-modal" class="modal-backdrop hidden" role="dialog" aria-modal="true">
+      <section class="modal">
+        <h1>Connexion à Supabase</h1>
+        <p>Configurez la connexion Supabase pour proposer vos disponibilités.</p>
+        <form id="connection-form" class="card">
+          <label for="supabaseUrl">URL Supabase</label>
+          <input id="supabaseUrl" name="supabaseUrl" type="url" required />
+
+          <label for="supabaseKey">Clé API</label>
+          <input id="supabaseKey" name="supabaseKey" type="password" required />
+
+          <div class="stack" style="justify-content: flex-end;">
+            <button type="submit">Se connecter</button>
+          </div>
+        </form>
+      </section>
+    </div>
+    <main>
+      <section class="card">
+        <header>
+          <div>
+            <h1>Espace Remplaçant</h1>
+            <p>Signalez vos disponibilités pour les gardes.</p>
+          </div>
+          <nav>
+            <button id="disconnect" class="secondary" type="button">Changer d'instance</button>
+            <button id="logout" class="secondary" type="button">Se déconnecter</button>
+          </nav>
+        </header>
+        <section>
+          <h2>Nouvelle disponibilité</h2>
+          <form id="availability-form">
+            <label for="availability-date">Date</label>
+            <input id="availability-date" name="date" type="date" required />
+
+            <label for="availability-slot">Créneau proposé</label>
+            <select id="availability-slot" name="slot" required>
+              <option value="Matin">Matin</option>
+              <option value="Après-midi">Après-midi</option>
+              <option value="Nuit">Nuit</option>
+            </select>
+
+            <label for="availability-notes">Notes</label>
+            <textarea id="availability-notes" name="notes" rows="3" placeholder="Précisions"></textarea>
+
+            <button type="submit">Publier ma disponibilité</button>
+            <p id="availability-feedback" role="status"></p>
+          </form>
+        </section>
+        <section>
+          <h2>Mes disponibilités</h2>
+          <div class="card">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Créneau</th>
+                  <th>Notes</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="availability-body"></tbody>
+            </table>
+            <p id="availability-list-feedback" role="status"></p>
+          </div>
+        </section>
+      </section>
+    </main>
+    <script type="module">
+      import {
+        initializeConnectionModal,
+        requireRole,
+        getCurrentUser,
+        setCurrentUser,
+        getSupabaseClient,
+        onSupabaseReady
+      } from './js/supabaseClient.js';
+
+      const user = getCurrentUser();
+      if (!user) {
+        window.location.replace('index.html');
+      }
+      requireRole('remplacant');
+
+      initializeConnectionModal();
+
+      document.querySelector('#logout').addEventListener('click', () => {
+        setCurrentUser(null);
+        window.location.replace('index.html');
+      });
+
+      const form = document.querySelector('#availability-form');
+      const feedback = document.querySelector('#availability-feedback');
+      const tableBody = document.querySelector('#availability-body');
+      const listFeedback = document.querySelector('#availability-list-feedback');
+      let channel;
+
+      const formatDate = (value) => new Intl.DateTimeFormat('fr-FR').format(new Date(value));
+
+      const renderAvailabilities = (entries) => {
+        tableBody.innerHTML = '';
+        entries.forEach((entry) => {
+          const row = document.createElement('tr');
+          row.innerHTML = `
+            <td>${formatDate(entry.date)}</td>
+            <td><span class="badge">${entry.slot}</span></td>
+            <td>${entry.notes ?? ''}</td>
+            <td>
+              <div class="table-actions">
+                <button data-action="delete" data-id="${entry.id}" class="danger">Supprimer</button>
+              </div>
+            </td>
+          `;
+          tableBody.appendChild(row);
+        });
+      };
+
+      const loadAvailabilities = async () => {
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        const { data, error } = await supabase
+          .from('replacement_entries')
+          .select('id, date, slot, notes')
+          .eq('user_id', user.id)
+          .order('date', { ascending: true });
+        if (error) {
+          console.error(error);
+          listFeedback.textContent = 'Impossible de récupérer vos disponibilités.';
+          return;
+        }
+        listFeedback.textContent = `${data.length} disponibilité(s).`;
+        renderAvailabilities(data);
+      };
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        const formData = new FormData(form);
+        const payload = {
+          user_id: user.id,
+          date: formData.get('date'),
+          slot: formData.get('slot'),
+          notes: formData.get('notes')?.trim() || null
+        };
+
+        const { error } = await supabase.from('replacement_entries').insert(payload);
+        if (error) {
+          console.error(error);
+          feedback.textContent = "Impossible d'enregistrer la disponibilité.";
+          return;
+        }
+
+        feedback.textContent = 'Disponibilité enregistrée !';
+        form.reset();
+      });
+
+      tableBody.addEventListener('click', async (event) => {
+        const button = event.target.closest('button');
+        if (!button) {
+          return;
+        }
+        if (button.dataset.action === 'delete') {
+          if (!confirm('Supprimer cette disponibilité ?')) {
+            return;
+          }
+          await onSupabaseReady();
+          const supabase = getSupabaseClient();
+          const { error } = await supabase.from('replacement_entries').delete().eq('id', button.dataset.id);
+          if (error) {
+            console.error(error);
+            alert('Impossible de supprimer la disponibilité.');
+          }
+        }
+      });
+
+      const subscribe = async () => {
+        await onSupabaseReady();
+        const supabase = getSupabaseClient();
+        channel = supabase
+          .channel('replacement-entries')
+          .on('postgres_changes', { event: '*', schema: 'public', table: 'replacement_entries', filter: `user_id=eq.${user.id}` }, () => {
+            loadAvailabilities();
+          })
+          .subscribe();
+      };
+
+      loadAvailabilities();
+      subscribe();
+
+      window.addEventListener('beforeunload', () => {
+        channel?.unsubscribe();
+      });
+    </script>
+  </body>
+</html>

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -1,0 +1,60 @@
+-- Schéma Supabase pour l'outil de gestion des gardes
+-- À exécuter dans la console SQL de Supabase
+
+-- Génération d'identifiants UUID
+create extension if not exists "pgcrypto";
+
+create table if not exists public.users (
+  id uuid primary key default gen_random_uuid(),
+  username text unique not null,
+  password text not null,
+  role text not null check (role in ('administrateur', 'medecin', 'remplacant')),
+  created_at timestamptz not null default now()
+);
+
+insert into public.users (username, password, role)
+values ('admin', 'Melatonine', 'administrateur')
+on conflict (username) do nothing;
+
+create table if not exists public.doctor_entries (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  date date not null,
+  type text not null,
+  notes text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists doctor_entries_user_id_idx on public.doctor_entries (user_id, date);
+
+create table if not exists public.replacement_entries (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  date date not null,
+  slot text not null,
+  notes text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists replacement_entries_user_id_idx on public.replacement_entries (user_id, date);
+
+-- Activez la Row Level Security si vous souhaitez utiliser une clé anon.
+alter table public.users enable row level security;
+alter table public.doctor_entries enable row level security;
+alter table public.replacement_entries enable row level security;
+
+-- Politiques d'exemple (à adapter selon vos besoins de sécurité)
+create policy if not exists "Allow service role" on public.users
+  for all
+  using (true)
+  with check (true);
+
+create policy if not exists "Allow service role" on public.doctor_entries
+  for all
+  using (true)
+  with check (true);
+
+create policy if not exists "Allow service role" on public.replacement_entries
+  for all
+  using (true)
+  with check (true);


### PR DESCRIPTION
## Summary
- add Supabase-backed login view that routes users by role
- build dedicated admin, médecin, et remplaçant espaces with realtime updates
- document setup and provide SQL schema including default admin account

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e53529282c8321ba89c6aa242490db