### PR TITLE
Improve planning headers and modal usability

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -68,8 +68,8 @@
             </div>
           </form>
 
-          <div class="planning-config" id="planning-config" aria-live="polite"></div>
           <div class="planning-tables" id="planning-tables" aria-live="polite"></div>
+          <div class="planning-config" id="planning-config" aria-live="polite"></div>
         </section>
 
         <footer class="admin-footer" aria-labelledby="create-title">
@@ -681,20 +681,33 @@
           const slotColor = normalizeColor(slot.color);
           button.style.setProperty('--slot-color', slotColor);
           const title = slot.label ?? `Colonne ${slot.position}`;
-          const metaParts = [];
-          if (slot.type_code) {
-            metaParts.push(slot.type_code);
+          const slotNumber = String(slot.position).padStart(2, '0');
+          const slotType = slot.type_code ?? '';
+          const slotTime = slot.start_time && slot.end_time ? `${slot.start_time} – ${slot.end_time}` : '';
+          button.innerHTML = '';
+          const numberSpan = document.createElement('span');
+          numberSpan.className = 'planning-slot-number';
+          numberSpan.textContent = slotNumber;
+          button.appendChild(numberSpan);
+
+          const labelSpan = document.createElement('span');
+          labelSpan.className = 'planning-slot-label';
+          labelSpan.textContent = title;
+          button.appendChild(labelSpan);
+
+          if (slotType) {
+            const typeSpan = document.createElement('span');
+            typeSpan.className = 'planning-slot-type';
+            typeSpan.textContent = slotType;
+            button.appendChild(typeSpan);
           }
-          if (slot.type_category) {
-            metaParts.push(slot.type_category);
+
+          if (slotTime) {
+            const timeSpan = document.createElement('span');
+            timeSpan.className = 'planning-slot-time';
+            timeSpan.textContent = slotTime;
+            button.appendChild(timeSpan);
           }
-          if (slot.start_time && slot.end_time) {
-            metaParts.push(`${slot.start_time} – ${slot.end_time}`);
-          }
-          button.innerHTML = `
-            <span class="planning-slot-label">${title}</span>
-            <span class="planning-slot-meta">${metaParts.join(' · ')}</span>
-          `;
           th.appendChild(button);
           headerRow.appendChild(th);
         });
@@ -742,10 +755,10 @@
             const open = isSlotOpen(slot, segment);
             const content = document.createElement('div');
             content.className = 'planning-summary-content';
-            const label = document.createElement('span');
-            label.className = 'planning-summary-label';
-            label.textContent = slot.label ?? slot.type_code ?? `Colonne ${slot.position}`;
-            content.appendChild(label);
+            const typeLabel = document.createElement('span');
+            typeLabel.className = 'planning-summary-label';
+            typeLabel.textContent = slot.type_code ?? slot.label ?? `Colonne ${slot.position}`;
+            content.appendChild(typeLabel);
             if (slot.start_time && slot.end_time) {
               const schedule = document.createElement('span');
               schedule.className = 'planning-summary-time';

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -442,25 +442,40 @@ main {
   display: grid;
   gap: 4px;
   width: 100%;
-  background: transparent;
-  border: none;
   text-align: left;
-  padding: 8px;
-  border-radius: 8px;
-  border-left: 4px solid var(--slot-color, #3498db);
-  background: rgba(52, 152, 219, 0.12);
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(248, 250, 252, 0.85);
   color: inherit;
+  border-top: 4px solid var(--slot-color, #3498db);
 }
 
 .planning-slot-button:hover {
-  background: rgba(52, 152, 219, 0.2);
+  border-color: rgba(52, 152, 219, 0.45);
+  box-shadow: 0 10px 18px rgba(52, 152, 219, 0.18);
+}
+
+.planning-slot-number {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.65);
 }
 
 .planning-slot-label {
   font-weight: 600;
+  color: #0f172a;
 }
 
-.planning-slot-meta {
+.planning-slot-type {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.85);
+  font-weight: 600;
+}
+
+.planning-slot-time {
   font-size: 0.85rem;
   color: rgba(44, 62, 80, 0.7);
 }
@@ -672,8 +687,11 @@ header nav {
   position: fixed;
   inset: 0;
   background: rgba(15, 23, 42, 0.55);
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  overflow-y: auto;
+  padding: 32px 16px;
   z-index: 1000;
 }
 
@@ -681,10 +699,21 @@ header nav {
   background: #fff;
   padding: 32px;
   border-radius: var(--radius);
-  width: min(480px, 90vw);
+  width: min(520px, 90vw);
   box-shadow: var(--shadow);
   display: grid;
   gap: 16px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-actions {
+  position: sticky;
+  bottom: -32px;
+  background: linear-gradient(to top, #fff 70%, rgba(255, 255, 255, 0));
+  padding-top: 16px;
+  padding-bottom: 16px;
+  margin-bottom: -16px;
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- add column numbers and show only type and schedule in planning headers for easier reference
- display the planning tables before the configuration recap to match the desired layout
- improve the planning modal scrolling experience and keep the action buttons visible for saving

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6476f97c08321b34dd61a062cefd1