### PR TITLE
Refine planning column headers and configuration modal

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -167,32 +167,42 @@
         <form id="slot-form">
           <input type="hidden" name="position" id="slot-position" />
 
-          <label for="slot-label">Nom de la colonne</label>
-          <input id="slot-label" name="label" type="text" required />
+          <div class="slot-grid">
+            <div class="slot-field-group">
+              <label for="slot-label">Nom de la colonne</label>
+              <input id="slot-label" name="label" type="text" required />
+            </div>
 
-          <label for="slot-type-code">Type de colonne (acronyme)</label>
-          <input id="slot-type-code" name="typeCode" type="text" required />
+            <div class="slot-field-group">
+              <label for="slot-type-code">Type de colonne (acronyme)</label>
+              <input id="slot-type-code" name="typeCode" type="text" required />
+            </div>
 
-          <label for="slot-type-category">Catégorie</label>
-          <select id="slot-type-category" name="typeCategory" required>
-            <option value="Visite">Visite</option>
-            <option value="Consultation">Consultation</option>
-            <option value="Téléconsultation">Téléconsultation</option>
-          </select>
+            <div class="slot-field-group">
+              <label for="slot-type-category">Catégorie</label>
+              <select id="slot-type-category" name="typeCategory" required>
+                <option value="Visite">Visite</option>
+                <option value="Consultation">Consultation</option>
+                <option value="Téléconsultation">Téléconsultation</option>
+              </select>
+            </div>
+
+            <div class="slot-field-group">
+              <label for="slot-color">Couleur</label>
+              <input id="slot-color" name="color" type="color" value="#1e293b" />
+            </div>
+          </div>
 
           <div class="slot-times">
-            <div>
+            <div class="slot-field-group">
               <label for="slot-start">Début</label>
               <input id="slot-start" name="startTime" type="time" />
             </div>
-            <div>
+            <div class="slot-field-group">
               <label for="slot-end">Fin</label>
               <input id="slot-end" name="endTime" type="time" />
             </div>
           </div>
-
-          <label for="slot-color">Couleur</label>
-          <input id="slot-color" name="color" type="color" value="#1e293b" />
           <fieldset class="slot-qualities">
             <legend>Qualité par période</legend>
             <div class="slot-qualities-grid">
@@ -505,6 +515,21 @@
 
       const formatBoolean = (value) => (value ? 'Oui' : 'Non');
 
+      const getSlotTimeRange = (slot) => {
+        const start = (slot.start_time ?? '').trim();
+        const end = (slot.end_time ?? '').trim();
+        if (start && end) {
+          return `${start} – ${end}`;
+        }
+        if (start) {
+          return `Début ${start}`;
+        }
+        if (end) {
+          return `Fin ${end}`;
+        }
+        return '';
+      };
+
       const selectToBoolean = (value, fallback = true) => {
         if (value === 'true') {
           return true;
@@ -648,8 +673,9 @@
         if (slot.type_category) {
           details.push(slot.type_category);
         }
-        if (slot.start_time && slot.end_time) {
-          details.push(`${slot.start_time} – ${slot.end_time}`);
+        const slotTime = getSlotTimeRange(slot);
+        if (slotTime) {
+          details.push(slotTime);
         }
         details.push(`Qualité : ${quality}`);
         details.push(isOpen ? 'Ouvert' : 'Fermé');
@@ -683,10 +709,21 @@
           const title = slot.label ?? `Colonne ${slot.position}`;
           const slotNumber = String(slot.position).padStart(2, '0');
           const slotType = slot.type_code ?? '';
-          const slotTime = slot.start_time && slot.end_time ? `${slot.start_time} – ${slot.end_time}` : '';
+          const slotTime = getSlotTimeRange(slot);
           button.innerHTML = '';
+          const buttonTitleParts = [slotNumber, title];
+          if (slotType) {
+            buttonTitleParts.push(slotType);
+          }
+          if (slotTime) {
+            buttonTitleParts.push(slotTime);
+          }
+          const buttonTitle = buttonTitleParts.join(' · ');
+          button.title = buttonTitle;
+          button.setAttribute('aria-label', buttonTitle);
           const numberSpan = document.createElement('span');
           numberSpan.className = 'planning-slot-number';
+          numberSpan.setAttribute('aria-hidden', 'true');
           numberSpan.textContent = slotNumber;
           button.appendChild(numberSpan);
 
@@ -759,10 +796,11 @@
             typeLabel.className = 'planning-summary-label';
             typeLabel.textContent = slot.type_code ?? slot.label ?? `Colonne ${slot.position}`;
             content.appendChild(typeLabel);
-            if (slot.start_time && slot.end_time) {
+            const slotTime = getSlotTimeRange(slot);
+            if (slotTime) {
               const schedule = document.createElement('span');
               schedule.className = 'planning-summary-time';
-              schedule.textContent = `${slot.start_time} – ${slot.end_time}`;
+              schedule.textContent = slotTime;
               content.appendChild(schedule);
             }
             cell.appendChild(content);

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -440,10 +440,11 @@ main {
 
 .planning-slot-button {
   display: grid;
-  gap: 4px;
+  gap: 8px;
   width: 100%;
-  text-align: left;
-  padding: 12px;
+  text-align: center;
+  justify-items: center;
+  padding: 16px 12px;
   border-radius: 12px;
   border: 1px solid rgba(15, 23, 42, 0.12);
   background: rgba(248, 250, 252, 0.85);
@@ -457,27 +458,37 @@ main {
 }
 
 .planning-slot-number {
-  font-size: 0.75rem;
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(52, 152, 219, 0.16);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.65);
 }
 
 .planning-slot-label {
   font-weight: 600;
   color: #0f172a;
+  text-align: center;
 }
 
 .planning-slot-type {
   font-size: 0.85rem;
   color: rgba(15, 23, 42, 0.85);
   font-weight: 600;
+  text-align: center;
 }
 
 .planning-slot-time {
   font-size: 0.85rem;
   color: rgba(44, 62, 80, 0.7);
+  text-align: center;
 }
 
 .planning-summary-cell {
@@ -554,13 +565,60 @@ main {
 }
 
 .planning-modal {
-  width: min(560px, 90vw);
+  width: min(720px, 95vw);
+  max-width: 720px;
+}
+
+.slot-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.slot-field-group {
+  display: grid;
+  gap: 8px;
 }
 
 .slot-times {
   display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.slot-qualities,
+.slot-openings {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid #ecf0f1;
+  border-radius: 12px;
+  background: rgba(248, 250, 252, 0.7);
+}
+
+.slot-qualities legend,
+.slot-openings legend {
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.slot-qualities-grid,
+.slot-openings-grid {
+  display: grid;
+  gap: 12px 20px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.slot-openings-grid > div {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+}
+
+.slot-openings-grid h3 {
+  margin: 0 0 4px 0;
+  font-size: 1rem;
+  color: var(--accent);
 }
 
 .slot-days {
@@ -688,10 +746,10 @@ header nav {
   inset: 0;
   background: rgba(15, 23, 42, 0.55);
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   overflow-y: auto;
-  padding: 32px 16px;
+  padding: 48px 16px;
   z-index: 1000;
 }
 


### PR DESCRIPTION
## Summary
- center and highlight planning column numbers while surfacing time ranges in headers and cell legends
- add a shared formatter for slot time ranges so partial schedules are visible everywhere
- redesign the slot configuration modal layout to improve readability and keep actions accessible on all screen sizes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e649df5e0c8321bd75f861dc19a40d