### PR TITLE
Ajuster l'affichage des colonnes du planning

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -710,7 +710,6 @@
           const slotNumber = String(slot.position).padStart(2, '0');
           const slotType = slot.type_code ?? '';
           const slotTime = getSlotTimeRange(slot);
-          button.innerHTML = '';
           const buttonTitleParts = [slotNumber, title];
           if (slotType) {
             buttonTitleParts.push(slotType);
@@ -721,30 +720,10 @@
           const buttonTitle = buttonTitleParts.join(' · ');
           button.title = buttonTitle;
           button.setAttribute('aria-label', buttonTitle);
-          const numberSpan = document.createElement('span');
-          numberSpan.className = 'planning-slot-number';
-          numberSpan.setAttribute('aria-hidden', 'true');
-          numberSpan.textContent = slotNumber;
-          button.appendChild(numberSpan);
-
-          const labelSpan = document.createElement('span');
-          labelSpan.className = 'planning-slot-label';
-          labelSpan.textContent = title;
-          button.appendChild(labelSpan);
-
-          if (slotType) {
-            const typeSpan = document.createElement('span');
-            typeSpan.className = 'planning-slot-type';
-            typeSpan.textContent = slotType;
-            button.appendChild(typeSpan);
-          }
-
-          if (slotTime) {
-            const timeSpan = document.createElement('span');
-            timeSpan.className = 'planning-slot-time';
-            timeSpan.textContent = slotTime;
-            button.appendChild(timeSpan);
-          }
+          const srLabel = document.createElement('span');
+          srLabel.className = 'sr-only';
+          srLabel.textContent = buttonTitle;
+          button.appendChild(srLabel);
           th.appendChild(button);
           headerRow.appendChild(th);
         });
@@ -884,10 +863,14 @@
           posBadge.className = 'planning-config-position';
           posBadge.textContent = String(slot.position).padStart(2, '0');
           colCell.appendChild(posBadge);
-          const name = document.createElement('div');
-          name.className = 'planning-config-label';
-          name.textContent = slot.label ?? `Colonne ${slot.position}`;
-          colCell.appendChild(name);
+          const labelText = (slot.label ?? `Colonne ${slot.position}`).trim();
+          const typeText = (slot.type_code ?? '').trim();
+          if (labelText && labelText.toLowerCase() !== typeText.toLowerCase()) {
+            const name = document.createElement('div');
+            name.className = 'planning-config-label';
+            name.textContent = labelText;
+            colCell.appendChild(name);
+          }
           row.appendChild(colCell);
 
           const typeCell = document.createElement('td');
@@ -904,21 +887,22 @@
           row.appendChild(typeCell);
 
           const scheduleCell = document.createElement('td');
-          if (slot.start_time && slot.end_time) {
-            scheduleCell.textContent = `${slot.start_time} – ${slot.end_time}`;
-          } else {
-            scheduleCell.textContent = '—';
-          }
+          const schedule = getSlotTimeRange(slot);
+          scheduleCell.textContent = schedule || '—';
           row.appendChild(scheduleCell);
 
           const colorCell = document.createElement('td');
+          colorCell.className = 'planning-config-color-cell';
           const swatch = document.createElement('span');
           swatch.className = 'planning-config-color';
           swatch.style.backgroundColor = normalizeColor(slot.color);
+          swatch.setAttribute('aria-hidden', 'true');
           colorCell.appendChild(swatch);
           const colorValue = document.createElement('span');
+          colorValue.className = 'sr-only';
           colorValue.textContent = normalizeColor(slot.color);
           colorCell.appendChild(colorValue);
+          colorCell.title = normalizeColor(slot.color);
           row.appendChild(colorCell);
 
           const qualityCell = document.createElement('td');

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -9,10 +9,23 @@
   --radius: 12px;
   --shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
   --transition: 0.2s ease-in-out;
+  --focus-ring-color: #2563eb;
 }
 
 * {
   box-sizing: border-box;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 body {
@@ -280,11 +293,16 @@ main {
 
 .planning-config-color {
   display: inline-block;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 4px;
-  margin-right: 8px;
+  margin-right: 0;
   border: 1px solid rgba(44, 62, 80, 0.12);
+}
+
+.planning-config-color-cell {
+  text-align: center;
+  vertical-align: middle;
 }
 
 .planning-config-line {
@@ -408,13 +426,14 @@ main {
 .planning-table thead th {
   background: rgba(52, 152, 219, 0.08);
   font-size: 0.9rem;
-  text-align: left;
+  text-align: center;
   white-space: nowrap;
 }
 
 .planning-day-col {
   min-width: 220px;
   background: rgba(52, 152, 219, 0.1);
+  text-align: left;
 }
 
 .planning-day-header {
@@ -439,56 +458,31 @@ main {
 }
 
 .planning-slot-button {
-  display: grid;
-  gap: 8px;
-  width: 100%;
-  text-align: center;
-  justify-items: center;
-  padding: 16px 12px;
-  border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  background: rgba(248, 250, 252, 0.85);
-  color: inherit;
-  border-top: 4px solid var(--slot-color, #3498db);
-}
-
-.planning-slot-button:hover {
-  border-color: rgba(52, 152, 219, 0.45);
-  box-shadow: 0 10px 18px rgba(52, 152, 219, 0.18);
-}
-
-.planning-slot-number {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 36px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(52, 152, 219, 0.16);
-  color: var(--accent);
-  font-size: 0.85rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  background: var(--slot-color, #3498db);
+  transition: transform var(--transition), box-shadow var(--transition);
 }
 
-.planning-slot-label {
-  font-weight: 600;
-  color: #0f172a;
-  text-align: center;
+.planning-slot-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.18);
 }
 
-.planning-slot-type {
-  font-size: 0.85rem;
-  color: rgba(15, 23, 42, 0.85);
-  font-weight: 600;
-  text-align: center;
+.planning-slot-button:focus-visible {
+  outline: 3px solid var(--focus-ring-color);
+  outline-offset: 3px;
 }
 
-.planning-slot-time {
-  font-size: 0.85rem;
-  color: rgba(44, 62, 80, 0.7);
-  text-align: center;
+.planning-slot-button .sr-only {
+  position: absolute;
 }
 
 .planning-summary-cell {


### PR DESCRIPTION
## Summary
- réduire les boutons d'en-tête du planning pour n'afficher que la couleur tout en conservant une alternative accessible
- éviter la duplication des libellés dans le récapitulatif des colonnes et y exposer les horaires calculés
- affiner la présentation du nuancier avec un aperçu compact et sans texte superflu

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e64f2c194483218220124613bbb703