### PR TITLE
Refine planning table headers and layout

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -706,11 +706,12 @@
           button.className = 'planning-slot-button';
           const slotColor = normalizeColor(slot.color);
           button.style.setProperty('--slot-color', slotColor);
-          const title = slot.label ?? `Colonne ${slot.position}`;
           const slotNumber = String(slot.position).padStart(2, '0');
+          const rawLabel = (slot.label ?? '').trim();
+          const slotLabel = rawLabel || `Colonne ${slot.position}`;
           const slotType = slot.type_code ?? '';
           const slotTime = getSlotTimeRange(slot);
-          const buttonTitleParts = [slotNumber, title];
+          const buttonTitleParts = [slotNumber, slotLabel];
           if (slotType) {
             buttonTitleParts.push(slotType);
           }
@@ -720,6 +721,17 @@
           const buttonTitle = buttonTitleParts.join(' · ');
           button.title = buttonTitle;
           button.setAttribute('aria-label', buttonTitle);
+          const heading = document.createElement('span');
+          heading.className = 'planning-slot-heading';
+          const numberLabel = document.createElement('span');
+          numberLabel.className = 'planning-slot-number';
+          numberLabel.textContent = slotNumber;
+          heading.appendChild(numberLabel);
+          const titleLabel = document.createElement('span');
+          titleLabel.className = 'planning-slot-title';
+          titleLabel.textContent = slotLabel;
+          heading.appendChild(titleLabel);
+          button.appendChild(heading);
           const srLabel = document.createElement('span');
           srLabel.className = 'sr-only';
           srLabel.textContent = buttonTitle;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -35,13 +35,13 @@ body {
   color: var(--text);
   min-height: 100vh;
   display: flex;
-  align-items: flex-start;
+  align-items: stretch;
   justify-content: center;
 }
 
 main {
-  width: min(960px, 95vw);
-  margin: 48px auto;
+  width: min(1600px, 98vw);
+  margin: 32px auto;
   display: grid;
   gap: 32px;
 }
@@ -409,8 +409,8 @@ main {
 
 .planning-table {
   border-collapse: collapse;
-  width: max-content;
-  min-width: 100%;
+  width: 100%;
+  table-layout: fixed;
   background: rgba(255, 255, 255, 0.85);
   border-radius: 12px;
   overflow: hidden;
@@ -419,21 +419,27 @@ main {
 .planning-table th,
 .planning-table td {
   border: 1px solid #ecf0f1;
-  padding: 12px;
+  padding: 8px 6px;
   vertical-align: top;
 }
 
 .planning-table thead th {
   background: rgba(52, 152, 219, 0.08);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   text-align: center;
   white-space: nowrap;
 }
 
 .planning-day-col {
+  width: 220px;
   min-width: 220px;
   background: rgba(52, 152, 219, 0.1);
   text-align: left;
+}
+
+.planning-table thead th:not(.planning-day-col),
+.planning-table tbody td {
+  width: 78px;
 }
 
 .planning-day-header {
@@ -457,14 +463,16 @@ main {
   font-weight: 600;
 }
 
+
 .planning-slot-button {
   position: relative;
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
-  padding: 0;
+  gap: 4px;
+  width: 72px;
+  padding: 6px 4px;
   border-radius: 10px;
   border: 1px solid rgba(15, 23, 42, 0.18);
   background: var(--slot-color, #3498db);
@@ -485,20 +493,41 @@ main {
   position: absolute;
 }
 
+.planning-slot-heading {
+  display: grid;
+  gap: 2px;
+  text-transform: uppercase;
+  line-height: 1.1;
+  text-align: center;
+}
+
+.planning-slot-number {
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.planning-slot-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
 .planning-summary-cell {
   position: relative;
-  min-width: 150px;
-  padding: 12px;
+  min-width: 0;
+  padding: 8px 6px;
   border: 1px solid #ecf0f1;
   border-radius: 10px;
   background: rgba(148, 163, 184, 0.12);
   transition: transform var(--transition), box-shadow var(--transition);
+  word-break: break-word;
 }
 
 .planning-summary-content {
   display: grid;
   gap: 4px;
   align-content: start;
+  justify-items: center;
+  text-align: center;
 }
 
 .planning-summary-label {


### PR DESCRIPTION
## Summary
- update planning column headers to display the column number and title while keeping detailed information in the tooltip only
- tighten the planning table layout with fixed-width cells and centre-aligned content for a compact grid
- expand the main layout width so the planning view can use more of the available screen space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e651f5242483218204ae099d9e109d