### PR TITLE
Ensure planning header buttons align with matrix columns

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -476,12 +476,12 @@ main {
 
 .planning-slot-button {
   position: relative;
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 4px;
-  width: 72px;
+  width: 100%;
   padding: 6px 4px;
   border-radius: 10px;
   border: 1px solid rgba(15, 23, 42, 0.18);


### PR DESCRIPTION
## Summary
- stretch planning slot header buttons to fill their table columns for proper matrix alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67e34b6b88321aeb9a0256e77682a