### PR TITLE
Affiche les détails des créneaux dans le tableau de planning

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -818,6 +818,41 @@
             srLabel.className = 'sr-only';
             srLabel.textContent = summaryTitle;
             cell.appendChild(srLabel);
+
+            const slotLabel = (slot.label ?? '').trim() || `Colonne ${slot.position}`;
+            const content = document.createElement('div');
+            content.className = 'planning-summary-content';
+
+            const label = document.createElement('div');
+            label.className = 'planning-summary-label';
+            label.textContent = slotLabel;
+            content.appendChild(label);
+
+            const status = document.createElement('div');
+            status.className = 'planning-summary-status';
+            status.textContent = open ? 'Disponible' : 'Fermé';
+            content.appendChild(status);
+
+            const metaDetails = [];
+            const slotType = (slot.type_code ?? '').trim();
+            if (slotType) {
+              metaDetails.push(slotType);
+            }
+            if (quality) {
+              metaDetails.push(`Qualité : ${quality}`);
+            }
+            const slotTime = getSlotTimeRange(slot);
+            if (slotTime) {
+              metaDetails.push(slotTime);
+            }
+            if (metaDetails.length) {
+              const details = document.createElement('div');
+              details.className = 'planning-summary-details';
+              details.textContent = metaDetails.join(' • ');
+              content.appendChild(details);
+            }
+
+            cell.appendChild(content);
             cell.title = summaryTitle;
             row.appendChild(cell);
           });

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -544,7 +544,14 @@ main {
   font-weight: 600;
 }
 
-.planning-summary-time {
+.planning-summary-status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.planning-summary-details {
   font-size: 0.85rem;
   color: rgba(44, 62, 80, 0.65);
 }
@@ -556,7 +563,8 @@ main {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
 }
 
-.planning-summary-open .planning-summary-time {
+.planning-summary-open .planning-summary-status,
+.planning-summary-open .planning-summary-details {
   color: inherit;
   opacity: 0.85;
 }
@@ -568,7 +576,8 @@ main {
   cursor: not-allowed;
 }
 
-.planning-summary-closed .planning-summary-time {
+.planning-summary-closed .planning-summary-status,
+.planning-summary-closed .planning-summary-details {
   color: rgba(71, 85, 105, 0.75);
 }
 
@@ -1129,20 +1138,42 @@ main {
 
 .planning-summary-cell {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
-  height: 56px;
-  padding: 0;
+  min-height: 88px;
+  padding: 8px;
   border: 1px solid var(--planning-border);
   border-radius: 10px;
   background: #ffffff;
   transition: background var(--transition), box-shadow var(--transition), border-color var(--transition);
 }
 
-.planning-summary-content,
-.planning-summary-label,
-.planning-summary-time {
-  display: none;
+.planning-summary-content {
+  display: grid;
+  gap: 6px;
+  align-content: center;
+  justify-items: center;
+  text-align: center;
+}
+
+.planning-summary-label {
+  display: block;
+  font-weight: 600;
+  color: var(--planning-text);
+}
+
+.planning-summary-status {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--planning-sub);
+}
+
+.planning-summary-details {
+  font-size: 0.8rem;
+  color: var(--planning-sub);
+  line-height: 1.3;
 }
 
 .planning-summary-open {
@@ -1152,8 +1183,19 @@ main {
   box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
 }
 
+.planning-summary-open .planning-summary-status,
+.planning-summary-open .planning-summary-details {
+  color: var(--planning-cell-text, #ffffff);
+  opacity: 0.9;
+}
+
 .planning-summary-closed {
   background: var(--planning-muted);
+  color: var(--planning-sub);
+}
+
+.planning-summary-closed .planning-summary-status,
+.planning-summary-closed .planning-summary-details {
   color: var(--planning-sub);
 }
 


### PR DESCRIPTION
## Summary
- affiche le libellé, le statut et les métadonnées de chaque créneau dans les cellules du planning
- met à jour le style des cellules pour qu'elles se présentent comme un tableau lisible par colonne et par jour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e68dfb1d548321a8fbae578371d249