### PR TITLE
Add interactive planning slot buttons

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -459,6 +459,7 @@
       let planningChannel;
       let allUsers = [];
       let planningSlots = [];
+      const selectedPlanningCells = new Set();
       let planningLoading = false;
       let openPlanningConfigMenu = null;
 
@@ -481,25 +482,6 @@
       };
 
       const normalizeColor = (value) => sanitizeColor(value) ?? DEFAULT_COLOR;
-
-      const hexToRgba = (hex, alpha) => {
-        const sanitized = sanitizeColor(hex) ?? DEFAULT_COLOR;
-        const numeric = sanitized.slice(1);
-        const r = parseInt(numeric.slice(0, 2), 16);
-        const g = parseInt(numeric.slice(2, 4), 16);
-        const b = parseInt(numeric.slice(4, 6), 16);
-        return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-      };
-
-      const getContrastingTextColor = (hex) => {
-        const sanitized = sanitizeColor(hex) ?? DEFAULT_COLOR;
-        const numeric = sanitized.slice(1);
-        const r = parseInt(numeric.slice(0, 2), 16);
-        const g = parseInt(numeric.slice(2, 4), 16);
-        const b = parseInt(numeric.slice(4, 6), 16);
-        const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-        return luminance > 0.6 ? '#1e293b' : '#ffffff';
-      };
 
       const inferTypeCategory = (typeCode) => {
         if (typeof typeCode !== 'string') {
@@ -798,62 +780,50 @@
           orderedSlots.forEach((slot) => {
             const cell = document.createElement('td');
             cell.className = 'planning-summary-cell';
-            const slotColor = normalizeColor(slot.color);
             const segment = getDaySegment(day, isHoliday);
             const quality = getQualityForSegment(slot, segment);
             const open = isSlotOpen(slot, segment);
 
-            if (open) {
-              const textColor = getContrastingTextColor(slotColor);
-              cell.classList.add('planning-summary-open');
-              cell.style.setProperty('--planning-cell-color', slotColor);
-              cell.style.setProperty('--planning-cell-text', textColor);
-              cell.style.color = textColor;
+            const summaryTitle = buildSlotTitle(slot, dayName, isHoliday, holidayName, open, quality);
+            const slotKey = `${isoKey}:${slot.position}`;
+            const isSelected = selectedPlanningCells.has(slotKey);
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'planning-slot-toggle';
+            button.dataset.slotKey = slotKey;
+            button.dataset.day = isoKey;
+            button.dataset.position = String(slot.position);
+            button.dataset.state = open ? 'available' : 'closed';
+            button.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+
+            if (!open) {
+              button.disabled = true;
+              button.title = 'Fermé';
             } else {
-              cell.classList.add('planning-summary-closed');
+              button.title = summaryTitle;
             }
 
-            const summaryTitle = buildSlotTitle(slot, dayName, isHoliday, holidayName, open, quality);
+            if (isSelected && open) {
+              button.classList.add('is-selected');
+            }
+
+            const symbol = document.createElement('span');
+            symbol.className = 'planning-slot-toggle-symbol';
+            symbol.setAttribute('aria-hidden', 'true');
+            if (!open) {
+              symbol.textContent = 'Fermé';
+            } else {
+              symbol.textContent = isSelected ? '✔' : '○';
+            }
+            button.appendChild(symbol);
+
             const srLabel = document.createElement('span');
             srLabel.className = 'sr-only';
             srLabel.textContent = summaryTitle;
-            cell.appendChild(srLabel);
+            button.appendChild(srLabel);
 
-            const slotLabel = (slot.label ?? '').trim() || `Colonne ${slot.position}`;
-            const content = document.createElement('div');
-            content.className = 'planning-summary-content';
-
-            const label = document.createElement('div');
-            label.className = 'planning-summary-label';
-            label.textContent = slotLabel;
-            content.appendChild(label);
-
-            const status = document.createElement('div');
-            status.className = 'planning-summary-status';
-            status.textContent = open ? 'Disponible' : 'Fermé';
-            content.appendChild(status);
-
-            const metaDetails = [];
-            const slotType = (slot.type_code ?? '').trim();
-            if (slotType) {
-              metaDetails.push(slotType);
-            }
-            if (quality) {
-              metaDetails.push(`Qualité : ${quality}`);
-            }
-            const slotTime = getSlotTimeRange(slot);
-            if (slotTime) {
-              metaDetails.push(slotTime);
-            }
-            if (metaDetails.length) {
-              const details = document.createElement('div');
-              details.className = 'planning-summary-details';
-              details.textContent = metaDetails.join(' • ');
-              content.appendChild(details);
-            }
-
-            cell.appendChild(content);
-            cell.title = summaryTitle;
+            cell.appendChild(button);
             row.appendChild(cell);
           });
 
@@ -1577,6 +1547,42 @@
 
       if (planningTables) {
         planningTables.addEventListener('click', (event) => {
+          const toggle = event.target.closest('.planning-slot-toggle');
+          if (toggle) {
+            if (toggle.disabled) {
+              return;
+            }
+            const key = toggle.dataset.slotKey;
+            if (!key) {
+              return;
+            }
+            const symbol = toggle.querySelector('.planning-slot-toggle-symbol');
+            const srLabel = toggle.querySelector('.sr-only');
+            const summaryText = srLabel?.textContent?.trim() ?? '';
+            if (selectedPlanningCells.has(key)) {
+              selectedPlanningCells.delete(key);
+              toggle.classList.remove('is-selected');
+              toggle.setAttribute('aria-pressed', 'false');
+              if (symbol) {
+                symbol.textContent = '○';
+              }
+              if (summaryText) {
+                toggle.title = summaryText;
+              }
+            } else {
+              selectedPlanningCells.add(key);
+              toggle.classList.add('is-selected');
+              toggle.setAttribute('aria-pressed', 'true');
+              if (symbol) {
+                symbol.textContent = '✔';
+              }
+              if (summaryText) {
+                toggle.title = `${summaryText} · Sélectionné`;
+              }
+            }
+            return;
+          }
+
           const button = event.target.closest('.planning-slot-button');
           if (!button) {
             return;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -522,83 +522,84 @@ main {
 }
 
 .planning-summary-cell {
-  position: relative;
-  min-width: 0;
-  padding: 8px 6px;
-  border: 1px solid #ecf0f1;
-  border-radius: 10px;
-  background: rgba(148, 163, 184, 0.12);
-  transition: transform var(--transition), box-shadow var(--transition);
-  word-break: break-word;
-}
-
-.planning-summary-content {
-  display: grid;
-  gap: 4px;
-  align-content: start;
-  justify-items: center;
+  padding: 12px;
+  border: none;
+  background: transparent;
   text-align: center;
 }
 
-.planning-summary-label {
+.planning-slot-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  min-height: 72px;
+  margin: 0 auto;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: #ffffff;
+  color: #1f2937;
+  font: inherit;
   font-weight: 600;
+  font-size: 1.25rem;
+  padding: 0;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), box-shadow var(--transition), transform var(--transition);
 }
 
-.planning-summary-status {
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+.planning-slot-toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.18);
 }
 
-.planning-summary-details {
-  font-size: 0.85rem;
-  color: rgba(44, 62, 80, 0.65);
+.planning-slot-toggle:focus-visible {
+  outline: 3px solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
-.planning-summary-open {
-  background: var(--planning-cell-color, #1e293b);
-  border-color: rgba(255, 255, 255, 0.18);
-  color: var(--planning-cell-text, #ffffff);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+.planning-slot-toggle-symbol {
+  line-height: 1;
 }
 
-.planning-summary-open .planning-summary-status,
-.planning-summary-open .planning-summary-details {
-  color: inherit;
-  opacity: 0.85;
+.planning-slot-toggle[data-state='available'] {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.6);
 }
 
-.planning-summary-closed {
-  background: rgba(148, 163, 184, 0.22);
-  color: rgba(30, 41, 59, 0.6);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+.planning-slot-toggle[data-state='available']:hover {
+  background: rgba(59, 130, 246, 0.16);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.planning-slot-toggle[data-state='closed'] {
   cursor: not-allowed;
+  background: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.5);
+  color: #94a3b8;
+  box-shadow: none;
 }
 
-.planning-summary-closed .planning-summary-status,
-.planning-summary-closed .planning-summary-details {
-  color: rgba(71, 85, 105, 0.75);
+.planning-slot-toggle[data-state='closed'] .planning-slot-toggle-symbol {
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
-.planning-summary-cell:hover {
-  transform: translateY(-1px);
+.planning-slot-toggle.is-selected {
+  background: #dbeafe;
+  border-color: #60a5fa;
+  color: #1d4ed8;
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.35);
 }
 
-.planning-summary-closed:hover::after {
-  content: '🚫';
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  font-size: 1rem;
-  opacity: 0.8;
+.planning-slot-toggle.is-selected .planning-slot-toggle-symbol {
+  color: inherit;
 }
 
 .planning-holiday .planning-day-header {
   background: rgba(231, 76, 60, 0.08);
 }
 
-.planning-holiday .planning-summary-cell {
+.planning-holiday .planning-slot-toggle {
   box-shadow: inset 0 0 0 1px rgba(231, 76, 60, 0.2);
 }
 
@@ -1137,74 +1138,77 @@ main {
 }
 
 .planning-summary-cell {
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  min-height: 88px;
-  padding: 8px;
-  border: 1px solid var(--planning-border);
-  border-radius: 10px;
-  background: #ffffff;
-  transition: background var(--transition), box-shadow var(--transition), border-color var(--transition);
-}
-
-.planning-summary-content {
-  display: grid;
-  gap: 6px;
-  align-content: center;
-  justify-items: center;
+  padding: 12px;
+  border: none;
+  background: transparent;
   text-align: center;
 }
 
-.planning-summary-label {
-  display: block;
-  font-weight: 600;
+.planning-slot-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  min-height: 72px;
+  margin: 0 auto;
+  border-radius: 14px;
+  border: 1px solid var(--planning-border);
+  background: var(--planning-surface, #ffffff);
   color: var(--planning-text);
+  font: inherit;
+  font-weight: 600;
+  font-size: 1.25rem;
+  padding: 0;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), box-shadow var(--transition), transform var(--transition);
 }
 
-.planning-summary-status {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--planning-sub);
+.planning-slot-toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.18);
 }
 
-.planning-summary-details {
-  font-size: 0.8rem;
-  color: var(--planning-sub);
-  line-height: 1.3;
+.planning-slot-toggle:focus-visible {
+  outline: 3px solid var(--planning-accent);
+  outline-offset: 2px;
 }
 
-.planning-summary-open {
-  background: var(--planning-cell-color, #2563eb);
-  color: var(--planning-cell-text, #ffffff);
-  border-color: transparent;
-  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+.planning-slot-toggle-symbol {
+  line-height: 1;
 }
 
-.planning-summary-open .planning-summary-status,
-.planning-summary-open .planning-summary-details {
-  color: var(--planning-cell-text, #ffffff);
-  opacity: 0.9;
+.planning-slot-toggle[data-state='available'] {
+  background: rgba(37, 99, 235, 0.08);
+  border-color: rgba(37, 99, 235, 0.35);
 }
 
-.planning-summary-closed {
+.planning-slot-toggle[data-state='available']:hover {
+  background: rgba(37, 99, 235, 0.16);
+  border-color: rgba(37, 99, 235, 0.5);
+}
+
+.planning-slot-toggle[data-state='closed'] {
+  cursor: not-allowed;
   background: var(--planning-muted);
-  color: var(--planning-sub);
+  border-color: rgba(148, 163, 184, 0.5);
+  color: rgba(71, 85, 105, 0.9);
+  box-shadow: none;
 }
 
-.planning-summary-closed .planning-summary-status,
-.planning-summary-closed .planning-summary-details {
-  color: var(--planning-sub);
+.planning-slot-toggle[data-state='closed'] .planning-slot-toggle-symbol {
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
-.planning-summary-cell:hover {
-  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+.planning-slot-toggle.is-selected {
+  background: #dbeafe;
+  border-color: #60a5fa;
+  color: #1d4ed8;
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.35);
 }
 
-.planning-summary-closed:hover::after {
-  content: none;
+.planning-slot-toggle.is-selected .planning-slot-toggle-symbol {
+  color: inherit;
 }
 
 .planning-holiday .planning-day-header {
@@ -1212,7 +1216,7 @@ main {
   border-left: 3px solid rgba(37, 99, 235, 0.5);
 }
 
-.planning-holiday .planning-summary-cell {
+.planning-holiday .planning-slot-toggle {
   border-color: rgba(37, 99, 235, 0.3);
 }
 
@@ -1221,7 +1225,7 @@ main {
   border-left: 3px solid var(--planning-danger);
 }
 
-.planning-sunday .planning-summary-cell {
+.planning-sunday .planning-slot-toggle {
   border-color: rgba(220, 38, 38, 0.3);
 }
 


### PR DESCRIPTION
## Summary
- replace the planning summary cells with centered toggle buttons that display open, closed, and selected states
- track client-side slot selection to switch between the available and selected visuals
- refresh the planning styles to align with the new toggle layout and state colors

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6947ac2388321b1e1f99b9e0cde15